### PR TITLE
whitelist urls needed to authenticate with organizations using okta

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -44,6 +44,10 @@ function allowedUrl(url) {
     'http://www.google.*/accounts/Logout2**',
     'https://inbox.google.com{**/**,**}',
     'https://{accounts.youtube,inbox.google}.com/accounts/@(SetOSID|SetSID)**',
+    'https://www.google.com/a/**/acs',
+    'https://**.okta.com/**',
+    'https://google.*/accounts/**',
+    'https://www.google.**/accounts/signin/continue**',
   ];
 
   return minimatch(url, urls);


### PR DESCRIPTION
I think a better solution should be to keep track of the auth process and whitelist all the URLs until the process is done but at least this allows me to login with my employer who happens to use okta.